### PR TITLE
Organize postdoc corpus: add `docs/omega_posdoc/` with refactor & falsifiability protocols

### DIFF
--- a/INDICE_NAVEGACAO.md
+++ b/INDICE_NAVEGACAO.md
@@ -13,6 +13,7 @@
 | [DISSERTACAO_ACADEMICA.md](DISSERTACAO_ACADEMICA.md) | Dissertação completa com fundamentação teórica | Acadêmico |
 | [ManifestRa.md](ManifestRa.md) | Manifesto espiritual-científico | Filosófico |
 | [Entropia.md](Entropia.md) | Notas sobre entropia e organização sistêmica | Técnico |
+| [docs/omega_posdoc/README.md](docs/omega_posdoc/README.md) | Estrutura pós-doc para os MD recentes e protocolo de falsificabilidade | Acadêmico/Técnico |
 
 ### 💻 Código e Implementações
 

--- a/docs/omega_posdoc/00_INDICE_NAVEGAVEL.md
+++ b/docs/omega_posdoc/00_INDICE_NAVEGAVEL.md
@@ -1,0 +1,67 @@
+# Índice Navegável — Corpus dos últimos 2 dias
+
+## 1) Arquivos-base identificados no histórico recente
+
+Os seguintes documentos compõem o núcleo recente do corpus (últimos 2 dias):
+
+1. `Teoremas.md`
+2. `Teoremas2.md`
+3. `Teoriasraf.md`
+4. `Fisicarafaelmeloreis.md`
+5. `Rafael e omega.md`
+6. `Rafael teoria matemate partícula a matéria.md`
+7. `Parte dois.md`
+8. `Parte3.md`
+9. `Reforma.md`
+10. `Parte completa.md`
+11. `Base academicamente.md`
+12. `Mapate.md`
+13. `Radoispontozero.md`
+14. `Oega3.md`
+15. `Tem ra.md`
+16. `Novo novo.md`
+
+## 2) Organização por camadas acadêmicas
+
+### Camada A — Fundamentos matemáticos e formais
+- `Teoremas.md`
+- `Teoremas2.md`
+- `Teoriasraf.md`
+
+### Camada B — Ponte matemática ↔ física
+- `Fisicarafaelmeloreis.md`
+- `Rafael teoria matemate partícula a matéria.md`
+- `Rafael e omega.md`
+
+### Camada C — Consolidação de tratado e expansão temática
+- `Parte dois.md`
+- `Parte3.md`
+- `Reforma.md`
+- `Parte completa.md`
+- `Oega3.md`
+
+### Camada D — Inventário, aparato crítico e metamodelo
+- `Base academicamente.md`
+- `Mapate.md`
+- `Radoispontozero.md`
+- `Tem ra.md`
+- `Novo novo.md`
+
+## 3) Rota de leitura recomendada (pós-doc)
+
+1. **Fundação matemática:** `Teoremas.md` → `Teoremas2.md`.
+2. **Integração físico-formal:** `Fisicarafaelmeloreis.md` → `Rafael teoria matemate partícula a matéria.md`.
+3. **Corpo expandido do tratado:** `Parte dois.md` → `Parte3.md` → `Reforma.md` → `Parte completa.md`.
+4. **Metacamada crítica:** `Base academicamente.md` → `Mapate.md` → `Tem ra.md`.
+5. **Atualização de fronteira e agenda:** `Novo novo.md`.
+
+## 4) Metadados mínimos a preencher em cada documento
+
+Para padronizar o corpus, cada MD deve conter no topo:
+
+- **Status:** hipótese / formalização / revisão / consolidado.
+- **Versão semântica:** `vX.Y.Z`.
+- **Data ISO:** `AAAA-MM-DD`.
+- **Escopo:** matemática, física, biologia, computação, epistemologia.
+- **Nível de evidência:** teórico / simulação / experimental indireto / experimental direto.
+- **Dependências documentais:** quais arquivos anteriores são pré-requisito.

--- a/docs/omega_posdoc/01_ARQUITETURA_ESTRUTURAL_DO_CORPUS.md
+++ b/docs/omega_posdoc/01_ARQUITETURA_ESTRUTURAL_DO_CORPUS.md
@@ -1,0 +1,61 @@
+# Arquitetura Estrutural do Corpus (Refatoração Profissional)
+
+## 1. Objetivo arquitetural
+
+Transformar um conjunto textual extenso em uma arquitetura documental com:
+
+- rastreabilidade semântica;
+- separação entre teoria, método e evidência;
+- interoperabilidade com submissão acadêmica (paper, tese, relatório técnico).
+
+## 2. Diagrama lógico (camadas)
+
+```text
+[C0 Ontologia de Conceitos]
+      ↓
+[C1 Axiomas e Definições Formais]
+      ↓
+[C2 Proposições, Lemas e Teoremas]
+      ↓
+[C3 Modelos Computacionais e Simulação]
+      ↓
+[C4 Evidência Empírica, Métricas e Limites]
+      ↓
+[C5 Discussão Epistemológica e Programa de Pesquisa]
+```
+
+## 3. Mapeamento do corpus atual para as camadas
+
+- **C0–C2 (núcleo formal):** `Teoremas.md`, `Teoremas2.md`, `Teoriasraf.md`.
+- **C2–C3 (ponte modelagem):** `Fisicarafaelmeloreis.md`, `Rafael teoria matemate partícula a matéria.md`.
+- **C3–C5 (programa expandido):** `Parte dois.md`, `Parte3.md`, `Reforma.md`, `Parte completa.md`, `Oega3.md`.
+- **Governança de conhecimento (cross-layer):** `Mapate.md`, `Base academicamente.md`, `Radoispontozero.md`, `Tem ra.md`, `Novo novo.md`.
+
+## 4. Contrato de seção (template canônico)
+
+Cada seção técnica deve seguir a sequência:
+
+1. **Definição formal** (símbolos, domínio, codomínio, hipóteses).
+2. **Enunciado verificável** (teorema/proposição/hipótese).
+3. **Demonstração ou estratégia de prova**.
+4. **Predição quantitativa** (valor, intervalo, assinatura espectral, etc.).
+5. **Protocolo de teste** (dados, método, parâmetro de decisão).
+6. **Critério de refutação**.
+7. **Limitações e validade externa**.
+
+## 5. Padrão de nomenclatura e versionamento
+
+- Prefixar seções principais por identificador estável: `AX`, `DF`, `TH`, `MD`, `EX`, `RF`.
+  - Ex.: `TH-03 — Teorema da Redução Dimensional`.
+- Versionar documentos por semântica:
+  - `major`: mudança conceitual;
+  - `minor`: nova seção/resultado;
+  - `patch`: correção textual ou bibliográfica.
+
+## 6. Saídas acadêmicas esperadas (pipeline)
+
+- **Saída A:** Preprint matemático (foco C1–C2).
+- **Saída B:** Paper de modelagem computacional (foco C2–C4).
+- **Saída C:** Artigo de integração interdisciplinar (foco C4–C5).
+
+Essa decomposição evita sobrecarga narrativa e aumenta auditabilidade por pares.

--- a/docs/omega_posdoc/02_PROTOCOLO_DE_REFATORACAO.md
+++ b/docs/omega_posdoc/02_PROTOCOLO_DE_REFATORACAO.md
@@ -1,0 +1,60 @@
+# Protocolo de Refatoração dos MD recentes
+
+## 1) Escopo
+
+Refatoração dos 16 arquivos recentes com foco em:
+
+- formalidade pós-doc;
+- precisão terminológica;
+- redução de ambiguidade;
+- consistência entre notação e bibliografia.
+
+## 2) Estratégia em 4 fases
+
+### Fase 1 — Saneamento editorial
+- Remover redundâncias e trechos meramente conversacionais.
+- Uniformizar língua, notação e estilo (voz acadêmica).
+- Corrigir títulos para padrão técnico.
+
+### Fase 2 — Estrutura científica
+- Converter blocos argumentativos em blocos formais (`definição`, `proposição`, `método`, `resultado`).
+- Inserir hipóteses explícitas (H1, H2, H3...).
+- Delimitar escopo de validade em cada afirmação.
+
+### Fase 3 — Referenciação e evidência
+- Associar cada afirmação central a DOI/preprint/livro técnico.
+- Distinguir:
+  - evidência de literatura;
+  - evidência de simulação;
+  - evidência experimental direta.
+
+### Fase 4 — Integração documental
+- Criar backlinks entre arquivos por dependência lógica.
+- Publicar changelog técnico por versão.
+- Consolidar índice e matriz de rastreabilidade.
+
+## 3) Regras de qualidade (obrigatórias)
+
+1. Não declarar validação universal sem condições de teste.
+2. Não usar linguagem conclusiva sem métrica associada.
+3. Toda hipótese deve ter potencial de refutação explícito.
+4. Toda previsão deve definir unidade, escala e tolerância.
+5. Toda tabela deve informar fonte e data.
+
+## 4) Matriz de priorização (ordem de refatoração)
+
+1. `Teoremas.md` e `Teoremas2.md` (núcleo formal).
+2. `Rafael teoria matemate partícula a matéria.md` (núcleo de integração).
+3. `Base academicamente.md` e `Mapate.md` (governança do corpus).
+4. `Novo novo.md` (ponte com literatura recente).
+5. Documentos de expansão (`Parte*.md`, `Oega3.md`, `Tem ra.md`, `Radoispontozero.md`).
+
+## 5) Definição de pronto (Definition of Done)
+
+Um documento refatorado está pronto quando:
+
+- possui metadados completos;
+- possui estrutura formal mínima (definição → hipótese → método → critério de teste);
+- possui bibliografia verificável;
+- possui seção de limitações e riscos epistemológicos;
+- possui versão e histórico de mudanças.

--- a/docs/omega_posdoc/03_TESTE_DE_FALSIFICABILIDADE_E_VALIDACAO.md
+++ b/docs/omega_posdoc/03_TESTE_DE_FALSIFICABILIDADE_E_VALIDACAO.md
@@ -1,0 +1,66 @@
+# Protocolo de Falsificabilidade, Validação e Reprodutibilidade
+
+## 1. Princípio orientador
+
+Qualquer proposição do corpus deve ser testável por terceiros com:
+
+- dados acessíveis;
+- método replicável;
+- critérios de decisão definidos antes do teste.
+
+## 2. Esquema padrão de teste
+
+Para cada hipótese `Hk`:
+
+- **Hk (hipótese):** enunciado formal.
+- **Pk (predição):** variável observável e intervalo esperado.
+- **Mk (método):** procedimento estatístico/numérico.
+- **Dk (dados):** origem, janela temporal, limpeza.
+- **Fk (falsificação):** condição objetiva de rejeição.
+
+## 3. Exemplo canônico de registro
+
+```text
+H1: A métrica espectral S apresenta regime multifractal em escala e.
+P1: expoente alpha em [a_min, a_max] com estabilidade > 95%.
+M1: ajuste por regressão robusta + validação cruzada temporal.
+D1: série temporal pública com N observações, período T.
+F1: rejeitar H1 se alpha sair do intervalo em >= q% das janelas.
+```
+
+## 4. Métricas mínimas por tipo de estudo
+
+### 4.1 Matemático-formal
+- consistência lógica interna;
+- rastreabilidade de premissas;
+- inexistência de circularidade.
+
+### 4.2 Simulação
+- sensibilidade a parâmetros;
+- análise de estabilidade numérica;
+- benchmark contra baseline conhecido.
+
+### 4.3 Dados reais
+- separação treino/validação/teste;
+- estimativa de incerteza (IC, bootstrap ou bayesiano);
+- teste fora da amostra (out-of-sample).
+
+## 5. Reprodutibilidade operacional
+
+Checklist obrigatório para cada experimento:
+
+- versão do código;
+- versão do dataset;
+- seed aleatória;
+- hardware/ambiente;
+- script executável único de reprodução.
+
+## 6. Critérios de qualidade para submissão acadêmica
+
+Um bloco só pode entrar em paper quando cumprir simultaneamente:
+
+1. clareza formal;
+2. predição mensurável;
+3. teste reprodutível;
+4. critério de refutação explícito;
+5. discussão de limitações.

--- a/docs/omega_posdoc/04_REFERENCIAS_E_TRILHAS_DE_PAPER.md
+++ b/docs/omega_posdoc/04_REFERENCIAS_E_TRILHAS_DE_PAPER.md
@@ -1,0 +1,55 @@
+# Referências Bibliográficas e Trilhas de Publicação
+
+## 1. Política de referência
+
+Para elevar o corpus ao padrão de publicação profissional:
+
+- priorizar fontes primárias (artigos, livros técnicos, repositórios oficiais);
+- usar DOI/ISBN/URL persistente sempre que possível;
+- marcar explicitamente o nível de confiança de cada referência.
+
+## 2. Estrutura recomendada de bibliografia
+
+Cada entrada deve conter:
+
+- autores;
+- ano;
+- título;
+- venue/editora;
+- identificador persistente (DOI/ISBN/arXiv);
+- tipo de evidência suportada no texto.
+
+## 3. Matriz referência ↔ afirmação
+
+Criar tabela com colunas:
+
+- `ID_afirmacao`;
+- `trecho_documento`;
+- `tipo` (teórica, empírica, revisão);
+- `fonte_primária`;
+- `status` (verificada / pendente / contestada).
+
+## 4. Três trilhas de paper (template)
+
+### Paper A — Fundamentos matemáticos
+- foco: axiomas, teoremas, provas e limites de validade.
+- saída ideal: periódico de matemática aplicada/fundamentos.
+
+### Paper B — Modelagem computacional
+- foco: algoritmo, simulação, performance, comparação com baseline.
+- saída ideal: periódico de sistemas complexos ou ciência computacional.
+
+### Paper C — Integração interdisciplinar
+- foco: interface matemática-física-biologia e implicações epistemológicas.
+- saída ideal: journal de estudos interdisciplinares com revisão metodológica robusta.
+
+## 5. Cronograma de maturação (90 dias)
+
+- **D+0 a D+15:** refatoração formal e metadados.
+- **D+16 a D+45:** testes reprodutíveis e validação interna.
+- **D+46 a D+70:** escrita dos três manuscritos.
+- **D+71 a D+90:** revisão por pares internos, ajustes e submissão.
+
+## 6. Resultado esperado
+
+Ao final, o repositório passa a operar como **base técnico-acadêmica auditável**, com navegação clara entre hipótese, método, evidência e falsificação.

--- a/docs/omega_posdoc/README.md
+++ b/docs/omega_posdoc/README.md
@@ -1,0 +1,28 @@
+# Diretório Pós-Doutoral — Corpus Omega (Últimos 2 dias)
+
+Este diretório organiza, em formato navegável e acadêmico, os arquivos Markdown produzidos nos **últimos 2 dias** do histórico do repositório, com foco em:
+
+- formalização matemática avançada;
+- arquitetura documental rastreável;
+- critérios de falsificabilidade acadêmica;
+- padronização para uso em dissertação, pré-print e submissão a periódico.
+
+## Estrutura
+
+- [`00_INDICE_NAVEGAVEL.md`](00_INDICE_NAVEGAVEL.md): navegação por trilhas temáticas e por estágio de maturidade científica.
+- [`01_ARQUITETURA_ESTRUTURAL_DO_CORPUS.md`](01_ARQUITETURA_ESTRUTURAL_DO_CORPUS.md): mapeamento estrutural (camadas, dependências e fluxo lógico).
+- [`02_PROTOCOLO_DE_REFATORACAO.md`](02_PROTOCOLO_DE_REFATORACAO.md): refatoração profissional dos documentos recentes, com padronização editorial e técnica.
+- [`03_TESTE_DE_FALSIFICABILIDADE_E_VALIDACAO.md`](03_TESTE_DE_FALSIFICABILIDADE_E_VALIDACAO.md): protocolo de testabilidade, reprodutibilidade e critérios de rejeição/aceitação.
+- [`04_REFERENCIAS_E_TRILHAS_DE_PAPER.md`](04_REFERENCIAS_E_TRILHAS_DE_PAPER.md): modelo de referências bibliográficas e trilhas de publicação.
+
+## Objetivo de qualidade
+
+Esta estrutura separa claramente:
+
+1. **Hipótese** (proposição autoral),
+2. **Formalização** (modelo matemático),
+3. **Previsão mensurável** (output esperado),
+4. **Experimento/observação** (método),
+5. **Critério de falsificação** (como a hipótese pode falhar).
+
+Com isso, o corpus passa de narrativa contínua para **programa de pesquisa verificável**.


### PR DESCRIPTION
### Motivation
- Provide a navigable, professional post‑doc structure for the Markdown files produced in the last 2 days, formalizing mathematical content, publication pathways and falsifiability criteria. 
- Prepare the corpus for systematic refactoring, reproducible testing and academic submission by separating hypothesis, formalization, prediction and test protocols.

### Description
- Add a new directory `docs/omega_posdoc/` containing `README.md`, `00_INDICE_NAVEGAVEL.md`, `01_ARQUITETURA_ESTRUTURAL_DO_CORPUS.md`, `02_PROTOCOLO_DE_REFATORACAO.md`, `03_TESTE_DE_FALSIFICABILIDADE_E_VALIDACAO.md` and `04_REFERENCIAS_E_TRILHAS_DE_PAPER.md` that define navigation, architecture, a 4‑phase refactor protocol, falsifiability/testing templates and bibliographic/paper roadmaps. 
- Update `INDICE_NAVEGACAO.md` to include a direct link to `docs/omega_posdoc/README.md` so the new postdoc structure is discoverable from the repository index. 
- Commit the added files and index change to the current branch (commit created 7 new files and one updated index) while leaving an unrelated untracked directory `android/.gradle/` untouched.

### Testing
- Ran `git diff --check` which completed with no warnings and returned success. 
- Verified repository state with `git status --short` which showed the staged changes and the untracked `android/.gradle/` entry. 
- Created and committed the new files successfully (commit message: "Organiza estrutura pós-doc para MD recentes com protocolo acadêmico").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d76ba73e74832d95c64e455644bf55)