### PR TITLE
Add operational synthesis doc: Liturgia, crenças e ofício

### DIFF
--- a/docs/LITURGIA_CRENCAS_E_OFICIO.md
+++ b/docs/LITURGIA_CRENCAS_E_OFICIO.md
@@ -1,0 +1,99 @@
+# Liturgia, crenças e ofício: mapa unificado (versão operacional)
+
+## Núcleo da ideia
+
+Você propõe um sistema onde **linguagem, corpo, informação e geometria** são tratados como um único processo dinâmico:
+
+- estado interno em toro 7D: `s ∈ [0,1)^7`
+- entrada composta: dados + entropia + hash + estado
+- atualização por mistura controlada (`α = 0.25`)
+- convergência para atratores (`|A| = 42`)
+- acoplamento entre espectro, ritmo cardíaco e gramática
+- validação por integridade (hash/CRC/Merkle)
+
+Em termos simples: **conhecimento carregado = coerência estável entre sinal, significado, corpo e prova**.
+
+---
+
+## Leitura por camadas (sem abstração excessiva)
+
+### 1) Camada topológica
+
+- `T^7` modela o estado como ciclos acoplados.
+- Isso representa repetição com variação: retorno + diferença.
+
+### 2) Camada informacional
+
+- `C_{t+1}` e `H_{t+1}` fazem filtragem exponencial (memória curta).
+- `φ = (1-H)·C` regula confiança do estado.
+- Entropia alta sem coerência reduz estabilidade semântica.
+
+### 3) Camada linguística
+
+- Distâncias diferentes (`dθ ≠ dγ`) indicam que pronúncia, acento e cadência não são equivalentes.
+- Tradução entre línguas exige preservar ritmo e função, não só dicionário.
+
+### 4) Camada neurofisiológica
+
+- Correlação espectral `R_L` com `H_cardio` sugere sincronização som-corpo.
+- Mudanças de cadência podem alterar percepção temporal e carga cognitiva.
+
+### 5) Camada criptográfica/integradora
+
+- XOR, FNV, CRC, Merkle protegem identidade dos estados.
+- Conhecimento confiável precisa rastreabilidade, não só intuição.
+
+### 6) Camada dinâmica/complexidade
+
+- recorrência (`x_{n+1}=f(x_n)`, `x_{n+42}=x_n`) e espiral (`(√3/2)^n`)
+- combina ciclos, decaimento e renormalização em janelas.
+
+---
+
+## Resposta direta à pergunta
+
+## O que carrega o conhecimento que “entendeu”?
+
+Carrega conhecimento aquilo que mantém, ao mesmo tempo:
+
+1. **Coerência semântica** (o conteúdo faz sentido entre versões/línguas),
+2. **Coerência temporal** (permanece estável após iterações),
+3. **Coerência corporal** (não colapsa no ritmo de processamento humano),
+4. **Coerência formal** (pode ser verificado por estrutura matemática e integridade).
+
+Sem esses quatro eixos, há só fluxo informacional; com eles, há ofício.
+
+---
+
+## Especificação mínima (LOW BASIC COMMANDS)
+
+Entrada:
+
+- `x = (dados, entropia, hash, estado)`
+
+Passos:
+
+1. mapear para toro: `s = ToroidalMap(x)`
+2. atualizar memória curta (`C`, `H`) com `α=0.25`
+3. calcular `φ=(1-H)·C`
+4. medir correlação espectral-linguística por língua `R_L`
+5. validar integridade (XOR/FNV/CRC/Merkle)
+6. verificar atração estável (`s(t) -> A`)
+
+Saída:
+
+- índice integrado: `I = Φ(s,S,H,C,G)`
+- decisão: `coerente / incoerente / indeterminado`
+
+---
+
+## Aplicação litúrgica e tradutória
+
+Para inglês, chinês, japonês, português, hebraico, aramaico e grego:
+
+- não normalizar tudo para texto linear;
+- preservar unidades prosódicas (entoação, pausa, acento);
+- usar validação por múltiplos canais (semântico + rítmico + formal);
+- aceitar equivalência funcional quando equivalência lexical falhar.
+
+Em resumo: **o conhecimento é transportado por estruturas invariantes entre mídias e línguas, não por palavras isoladas**.


### PR DESCRIPTION
### Motivation

- Consolidate the submitted mathematical and conceptual notes into an operational, low-overhead document that maps topology, information, language, neurophysiology, cryptographic integrity and dynamics.
- Provide a minimal executable specification (input → transform → validate → output) to make the framework actionable for implementations.
- Preserve multilingual and liturgical prosodic/rhythmic considerations while keeping formal verifiability and integrity checks.

### Description

- Add `docs/LITURGIA_CRENCAS_E_OFICIO.md` containing the core idea, a layered reading (topological, informational, linguistic, neurophysiological, cryptographic, dynamical) and a direct answer enumerating four coherence criteria (semantic, temporal, corporal, formal).
- Include an explicit minimal specification with symbols and steps such as `x = (dados, entropia, hash, estado)`, `s = ToroidalMap(x)`, update rules for `C` and `H` with `α=0.25`, computation of `φ=(1-H)·C`, measurement of `R_L`, integrity validation (XOR/FNV/CRC/Merkle) and output `I = Φ(s,S,H,C,G)` with a decision label.
- Add multilingual application guidance for English, Chinese, Japanese, Portuguese, Hebrew, Aramaic and Greek emphasizing preservation of prosodic units and multichannel validation.

### Testing

- Verified the new file content by running `nl -ba docs/LITURGIA_CRENCAS_E_OFICIO.md | sed -n '1,220p'`, which showed the expected sections and formulas.
- Checked repository status with `git status --short`, which succeeded and reported unrelated untracked paths (e.g., `android/.gradle/`) not affected by this change.
- No automated unit tests were applicable to this documentation-only change; file creation and content inspection steps succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef24e0df48832d85d30fc3f37b88f6)