### PR TITLE
Parse asset YAML with package:yaml and update pubspec

### DIFF
--- a/lib/marte/marte.dart
+++ b/lib/marte/marte.dart
@@ -2,7 +2,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
-import 'dart:convert';
+import 'package:yaml/yaml.dart';
 
 class MartePage extends StatefulWidget { const MartePage({super.key}); @override State<MartePage> createState()=>_MartePageState(); }
 
@@ -11,8 +11,13 @@ class _MartePageState extends State<MartePage> {
   @override void initState(){ super.initState(); _loadCfg(); }
   Future<void> _loadCfg() async {
     final y = await rootBundle.loadString('assets/utopia_marte.yaml');
-    // troque por um parser YAML real; aqui é placeholder de leitura
-    cfg = {'utopia_marte': y}; setState((){});
+    final parsed = loadYaml(y);
+    if (parsed is YamlMap) {
+      cfg = Map<String, dynamic>.from(parsed);
+    } else {
+      cfg = {'raw': y};
+    }
+    setState(() {});
   }
   @override Widget build(BuildContext context){
     return Scaffold(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  yaml: ^3.1.3
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
### Motivation
- Replace the placeholder YAML handling in `lib/marte/marte.dart` with a real YAML parser so the app can load structured configuration from `assets/utopia_marte.yaml`.

### Description
- Add the `yaml: ^3.1.3` dependency to `pubspec.yaml` to enable YAML parsing.
- Import `package:yaml/yaml.dart` in `lib/marte/marte.dart` and use `loadYaml` to parse the asset, converting a `YamlMap` into a `Map<String, dynamic>` and falling back to a raw string on unexpected types.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef29c299cc832da19305c59b9ccc0c)